### PR TITLE
change cache layer to 15 to enhance proof creation

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -12,7 +12,7 @@ import (
 	"github.com/tranvictor/ethashproof/mtree"
 )
 
-const CACHE_LEVEL uint64 = 10
+const CACHE_LEVEL uint64 = 15
 
 type DatasetMerkleTreeCache struct {
 	Epoch       uint64         `json:"epoch"`


### PR DESCRIPTION
On my local computer this produced a 2x speedup in proof calculation (now 4 secs per block instead of 8). Depth of 15 means 2^15 * 16B ~= 0.5MB per epoch (3 days), which I think is ok.